### PR TITLE
Renames session role enums for better understandability

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,5 +3,5 @@ class Session < ApplicationRecord
 	belongs_to :price_table
 	has_many :transactions
 	has_and_belongs_to_many :users
-	enum status: { available: 0, booked: 1, full: 2 }
+	enum status: { scheduled: 0, confirmed: 1, full: 2 }
 end

--- a/client/bundles/Main/components/sessions/AllSessions.jsx
+++ b/client/bundles/Main/components/sessions/AllSessions.jsx
@@ -17,11 +17,11 @@ export class AllSessions extends Component {
 	componentDidMount() {
 		let user = this.state.user;
 		let availability = this.state.sessionType;
-		
+
 		if (user) {
-			if (user.role === "coach" && availability === "booked" || availability === "full") {
+			if (user.role === "coach" && availability === "confirmed" || availability === "full") {
 				this.setState({ buttonName: "Start" });
-			} else if (user.role === "trainee" && availability === "available") {
+			} else if (user.role === "trainee" && availability === "scheduled") {
 				this.setState({ buttonName: "Book" });
 			} else {
 				this.setState({ buttonName: "Join" });

--- a/client/bundles/Main/components/sessions/MainSessionsDisplay.jsx
+++ b/client/bundles/Main/components/sessions/MainSessionsDisplay.jsx
@@ -4,8 +4,8 @@ import AllSessions from "./AllSessions";
 function MainSessionsDisplay(props) {
 	return (
 		<div>
-			<AllSessions sessionType="available" buttonName="Book" sessionlist={props} />
-			<AllSessions sessionType="booked" buttonName="Join" sessionlist={props} />
+			<AllSessions sessionType="scheduled" buttonName="Book" sessionlist={props} />
+			<AllSessions sessionType="confirmed" buttonName="Join" sessionlist={props} />
 			<AllSessions sessionType="full"  sessionlist={props} />
 		</div>
 	)

--- a/features/coach_can_create_and_start_videocall.feature
+++ b/features/coach_can_create_and_start_videocall.feature
@@ -19,8 +19,8 @@ Feature: Coach creates and starts videocall for session
 			| trainee@email.com | password | password              | Trainee-Jon | Doe       | trainee |
 
 		And the following sessions exist
-			| title    | start_date          | end_date            | status |
-			| Crossfit | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | booked |
+			| title    | start_date          | end_date            | status    |
+			| Crossfit | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | confirmed |
 
 		And I am logged in as 'coach@email.com'
 		And I visit the site

--- a/features/trainee_can_buy_a_session.feature
+++ b/features/trainee_can_buy_a_session.feature
@@ -19,7 +19,7 @@ Feature: User can buy a subscription
 
 		And the following sessions exist
 			| title    | start_date          | end_date            | status    | price_table_id |
-			| Crossfit | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | available | 1              |
+			| Crossfit | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | scheduled | 1              |
 		And the time is 2019 1 30 10:00:00
 
 	Scenario: Trainee can successfully buy a subscription

--- a/features/trainee_can_see_all_sessions.feature
+++ b/features/trainee_can_see_all_sessions.feature
@@ -12,15 +12,15 @@ Feature: Trainee can see all sessions
 
 		And the following sessions exist
 			| title     | start_date          | end_date            | status    |
-			| Crossfit  | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | available |
-			| Yoga      | 2019-02-01 19:00:00 | 2019-02-01 19:30:00 | booked    |
+			| Crossfit  | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | scheduled |
+			| Yoga      | 2019-02-01 19:00:00 | 2019-02-01 19:30:00 | confirmed |
 			| Body Pump | 2019-02-01 21:00:00 | 2019-02-01 21:30:00 | full      |
 
 	Scenario: Trainee can view all sessions on the Home Page
 		Given I am logged in as "real@email.com"
-		Then I should see 'CROSSFIT' in 'available'
-		And I should see '01/02/2019, 15:00:00' in 'available'
-		And I should see 'YOGA' in 'booked'
-		And I should see '01/02/2019, 19:00:00' in 'booked'
+		Then I should see 'CROSSFIT' in 'scheduled'
+		And I should see '01/02/2019, 15:00:00' in 'scheduled'
+		And I should see 'YOGA' in 'confirmed'
+		And I should see '01/02/2019, 19:00:00' in 'confirmed'
 		And I should see 'BODY PUMP' in 'full'
 		And I should see '01/02/2019, 21:00:00' in 'full'


### PR DESCRIPTION
Co-authored-by: Aditya Naik <naik.aditya@gmail.com>

# PT Link

[Renames session role enums ](https://www.pivotaltracker.com/story/show/163821166)

# Description of PR

Renames session role enums for better understandability
