### PR TITLE
Sessions on landing page

### DIFF
--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -3,7 +3,7 @@ import MainSessionsDisplay from "./sessions/MainSessionsDisplay";
 import MainNavLinks from "./MainNavLinks";
 import ReactOnRails from "react-on-rails";
 import logo from './logo.png';
-import LandingPageSessionDisplay from "./sessions/LandingPageSessionDisplay"
+import LandingPageSessionDisplay from "./sessions/LandingPageSessionDisplay";
 
 const axios = require("axios");
 

--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -53,8 +53,8 @@ export default class Main extends React.Component {
 					<MainNavLinks user={this.state.user} fbLogin = {this.fbLogin} logout={this.logout} />
 					<h4 className="m-4">Hello, {this.state.user ? this.state.user.first_name : 'Stranger'}!</h4>
 					<div style = {this.state.user? {display: "none"}:{} }>
-					<h1 className="capitalize"> Available sessions</h1>
-					<LandingPageSessionDisplay  sessions={this.state.sessions} />
+						<h1 className="capitalize"> Available sessions</h1>
+						<LandingPageSessionDisplay  sessions={this.state.sessions} />
 					</div>
 					<div style = {this.state.user? {}:{display: "none"} }>
 						<MainSessionsDisplay  sessions={this.state.sessions} />

--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import MainSessionsDisplay from "./sessions/MainSessionsDisplay";
 import MainNavLinks from "./MainNavLinks";
 import ReactOnRails from "react-on-rails";
-import logo from './logo.png'
+import logo from './logo.png';
+import LandingPageSessionDisplay from "./sessions/LandingPageSessionDisplay"
 
 const axios = require("axios");
 
@@ -51,6 +52,9 @@ export default class Main extends React.Component {
 				<div className='content wrapper-col'>
 					<MainNavLinks user={this.state.user} fbLogin = {this.fbLogin} logout={this.logout} />
 					<h4 className="m-4">Hello, {this.state.user ? this.state.user.first_name : 'Stranger'}!</h4>
+					<div>
+						<LandingPageSessionDisplay  sessions={this.state.sessions} />
+					</div>
 					<div style = {this.state.user? {}:{display: "none"} }>
 						<MainSessionsDisplay  sessions={this.state.sessions} />
 					</div>

--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -52,7 +52,7 @@ export default class Main extends React.Component {
 				<div className='content wrapper-col'>
 					<MainNavLinks user={this.state.user} fbLogin = {this.fbLogin} logout={this.logout} />
 					<h4 className="m-4">Hello, {this.state.user ? this.state.user.first_name : 'Stranger'}!</h4>
-					<div>
+					<div style = {this.state.user? {display: "none"}:{} }>
 						<LandingPageSessionDisplay  sessions={this.state.sessions} />
 					</div>
 					<div style = {this.state.user? {}:{display: "none"} }>

--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -53,7 +53,8 @@ export default class Main extends React.Component {
 					<MainNavLinks user={this.state.user} fbLogin = {this.fbLogin} logout={this.logout} />
 					<h4 className="m-4">Hello, {this.state.user ? this.state.user.first_name : 'Stranger'}!</h4>
 					<div style = {this.state.user? {display: "none"}:{} }>
-						<LandingPageSessionDisplay  sessions={this.state.sessions} />
+					<h1 className="capitalize"> Available sessions</h1>
+					<LandingPageSessionDisplay  sessions={this.state.sessions} />
 					</div>
 					<div style = {this.state.user? {}:{display: "none"} }>
 						<MainSessionsDisplay  sessions={this.state.sessions} />

--- a/client/bundles/Main/components/MainNavLinks.jsx
+++ b/client/bundles/Main/components/MainNavLinks.jsx
@@ -37,7 +37,7 @@ function MainNavLinks(props) {
 				</div>
 			</div>
 
-	)
+	);
 }
 
 export default MainNavLinks

--- a/client/bundles/Main/components/sessions/AllSessions.jsx
+++ b/client/bundles/Main/components/sessions/AllSessions.jsx
@@ -43,7 +43,7 @@ export class AllSessions extends Component {
 		return (
 			<div className='main_container'>
 				<div id={this.state.sessionType}>
-					<h1 className="capitalize">{this.state.sessionType} sessions</h1>
+					{/* <h1 className="capitalize">{this.state.sessionType} sessions</h1> */}
 					<div className='session_wrapper'>
 						<div>{allSessions}</div>
 					</div>

--- a/client/bundles/Main/components/sessions/AllSessions.jsx
+++ b/client/bundles/Main/components/sessions/AllSessions.jsx
@@ -43,7 +43,9 @@ export class AllSessions extends Component {
 		return (
 			<div className='main_container'>
 				<div id={this.state.sessionType}>
-					{/* <h1 className="capitalize">{this.state.sessionType} sessions</h1> */}
+					<div style = {this.state.user? {}:{display: "none"} }>
+						<h1 className="capitalize">{this.state.sessionType} sessions</h1>
+					</div>
 					<div className='session_wrapper'>
 						<div>{allSessions}</div>
 					</div>

--- a/client/bundles/Main/components/sessions/LandingPageSessionDisplay.jsx
+++ b/client/bundles/Main/components/sessions/LandingPageSessionDisplay.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import AllSessions from "./AllSessions";
+
+function LandingPageSessionDisplay(props) {
+	return (
+		<div>
+			<AllSessions sessionType="scheduled" sessionlist={props} />
+			<AllSessions sessionType="confirmed" sessionlist={props} />
+		</div>
+	)
+}
+
+export default LandingPageSessionDisplay

--- a/client/bundles/Main/components/sessions/LandingPageSessionDisplay.jsx
+++ b/client/bundles/Main/components/sessions/LandingPageSessionDisplay.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import AllSessions from "./AllSessions";
 
 function LandingPageSessionDisplay(props) {
@@ -7,7 +7,7 @@ function LandingPageSessionDisplay(props) {
 			<AllSessions sessionType="scheduled" sessionlist={props} />
 			<AllSessions sessionType="confirmed" sessionlist={props} />
 		</div>
-	)
+	);
 }
 
-export default LandingPageSessionDisplay
+export default LandingPageSessionDisplay;

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -83,3 +83,7 @@ Given("trainee Jon buys a session") do
 	session = Session.find_by(title: 'Crossfit')
   session.users << User.find_by(first_name: 'Jon')
 end
+
+Then("show me the page") do
+	save_and_open_page
+end

--- a/features/trainee_can_see_all_sessions.feature
+++ b/features/trainee_can_see_all_sessions.feature
@@ -18,9 +18,10 @@ Feature: Trainee can see all sessions
 
 	Scenario: Trainee can view all sessions on the Home Page
 		Given I am logged in as "real@email.com"
-		Then I should see 'CROSSFIT' in 'scheduled'
-		And I should see '01/02/2019, 15:00:00' in 'scheduled'
-		And I should see 'YOGA' in 'confirmed'
-		And I should see '01/02/2019, 19:00:00' in 'confirmed'
-		And I should see 'BODY PUMP' in 'full'
-		And I should see '01/02/2019, 21:00:00' in 'full'
+		Then I should see 'Available Sessions' 
+		And I should see 'CROSSFIT'
+		And I should see '01/02/2019, 15:00:00'
+		And I should see 'YOGA'
+		And I should see '01/02/2019, 19:00:00'
+		And I should see 'BODY PUMP'
+		And I should see '01/02/2019, 21:00:00'

--- a/features/trainee_can_see_all_sessions.feature
+++ b/features/trainee_can_see_all_sessions.feature
@@ -18,8 +18,7 @@ Feature: Trainee can see all sessions
 
 	Scenario: Trainee can view all sessions on the Home Page
 		Given I am logged in as "real@email.com"
-		Then I should see 'Available Sessions' 
-		And I should see 'CROSSFIT'
+        And I should see 'CROSSFIT'
 		And I should see '01/02/2019, 15:00:00'
 		And I should see 'YOGA'
 		And I should see '01/02/2019, 19:00:00'

--- a/features/visitor_can_see_list_of_available_sessions_on_landing_page.feature
+++ b/features/visitor_can_see_list_of_available_sessions_on_landing_page.feature
@@ -16,6 +16,7 @@ Feature: Visitor can see all available sessions on landing page
 		Given I visit the site
 		Then I should see 'LOGIN' 
         And I should see 'REGISTER'
+		And I should see 'Available Sessions' 
         And I should see 'CROSSFIT'
 		And I should see '01/02/2019, 15:00:00'
 		And I should see 'YOGA'

--- a/features/visitor_can_see_list_of_available_sessions_on_landing_page.feature
+++ b/features/visitor_can_see_list_of_available_sessions_on_landing_page.feature
@@ -1,0 +1,24 @@
+@javascript
+Feature: Visitor can see all available sessions on landing page
+
+    As a visitor,
+    In order to see all the exciting sessions available to me,
+    I would like to see all available sessions before logging in.
+
+	Background:
+		Given the following sessions exist
+			| title     | start_date          | end_date            | status    |
+			| Crossfit  | 2019-02-01 15:00:00 | 2019-02-01 15:30:00 | scheduled |
+			| Yoga      | 2019-02-01 19:00:00 | 2019-02-01 19:30:00 | confirmed |
+			| Body Pump | 2019-02-01 21:00:00 | 2019-02-01 21:30:00 | full      |
+
+	Scenario: Visitor can view all sessions on the Landing Page
+		Given I visit the site
+		Then I should see 'LOGIN' 
+        And I should see 'REGISTER'
+        And I should see 'CROSSFIT'
+		And I should see '01/02/2019, 15:00:00'
+		And I should see 'YOGA'
+		And I should see '01/02/2019, 19:00:00'
+		And I should not see 'BODY PUMP'
+		And I should not see '01/02/2019, 21:00:00'


### PR DESCRIPTION
# PT Link

[Visitor can see list of available sessions on landing page](https://www.pivotaltracker.com/story/show/163858132)

# User Story

```
As a visitor,
In order to see all the exciting sessions available to me,
I would like to see all available sessions before logging in.
```

# Screenshots

![landingpagesessions](https://user-images.githubusercontent.com/38586575/52581154-4c975100-2e2a-11e9-8a98-c290dbaf449c.gif)

# Description of PR

Adding list of available sessions on landing page.
